### PR TITLE
fix(contact): lowercase emails to avoid duplicates

### DIFF
--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -41,7 +41,7 @@ public class Email {
     public Email(String email) {
         requireNonNull(email);
         checkArgument(isValidEmail(email), MESSAGE_CONSTRAINTS);
-        value = email;
+        value = email.toLowerCase();
     }
 
     /**


### PR DESCRIPTION
User emails are now automatically converted to lowercase before saving a new contact. This ensures consistent handling of email addresses and prevents duplicate entries caused by case differences. Fix #59 