### PR TITLE
Update error messages for add meeting to be more specific

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -21,7 +21,8 @@ public class AddMeetingCommand extends ConfirmableCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a meeting time to a person in the address book.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_MEETING + "MEETING_TIME (format: DD-MM-YYYY HH:MM) Description(optional)\n"
+            + PREFIX_MEETING + "MEETING_TIME (format: DD-MM-YYYY HH:MM) Description(optional and less than 50 "
+            + "characters)\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_MEETING + "20-10-2025 14:30 Project LinkUp";
 
@@ -56,7 +57,7 @@ public class AddMeetingCommand extends ConfirmableCommand {
      *
      * @param model The model containing the address book and filtered person list.
      * @return A {@code CommandResult} with feedback of the operation.
-     * @throws CommandException If the index is invalid or the meeting already exists.
+     * @throws CommandException If the index is invalid.
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMeetingCommandParser.java
@@ -14,12 +14,17 @@ import seedu.address.model.person.Meeting;
 /**
  * Parses input arguments and creates a new {@link AddMeetingCommand} object.
  * <p>
- * Expected format: {@code addm INDEX m/MEETING_TIME [DESCRIPTION]}
+ * Expected format: {@code addm INDEX m/MEETING_TIME DESCRIPTION}
  * <br>
  * Example: {@code addm 1 m/20-10-2025 14:30 Project discussion}
  */
 public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
 
+    public static final String MESSAGE_INVALID_DESCRIPTION_LENGTH =
+            "Meeting description cannot be longer than 50 characters.";
+    public static final String MESSAGE_INVALID_MEETING_FORMAT =
+            "Meeting must follow the format DD-MM-YYYY HH:MM\n"
+            + "eg. 30-10-2020 12:30";
     /**
      * Parses the given {@code String} of arguments and returns an {@code AddMeetingCommand} object.
      *
@@ -46,18 +51,24 @@ public class AddMeetingCommandParser implements Parser<AddMeetingCommand> {
         String meetingInput = argMultimap.getValue(PREFIX_MEETING).get().trim();
         String[] parts = meetingInput.split(" ", 3); // Split on first two spaces (date, time, description)
         if (parts.length < 2) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_FORMAT));
         }
 
         String timePart = parts[0] + " " + parts[1]; // Combine date and time (DD-MM-YYYY HH:MM)
-        String description = parts.length > 2 ? parts[2] : null; // Description is optional
+        String description = null;
 
         LocalDateTime meetingTime;
         try {
             meetingTime = ParserUtil.parseMeetingTime(timePart);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    AddMeetingCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_MEETING_FORMAT), pe);
+        }
+
+        if (parts.length > 2) {
+            description = parts[2];
+            if (description.length() > 50) {
+                throw new ParseException(String.format(MESSAGE_INVALID_DESCRIPTION_LENGTH));
+            }
         }
 
         Meeting meeting = new Meeting(meetingTime, description);

--- a/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.AddMeetingCommandParser.MESSAGE_INVALID_DESCRIPTION_LENGTH;
+import static seedu.address.logic.parser.AddMeetingCommandParser.MESSAGE_INVALID_MEETING_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEETING;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -20,6 +22,9 @@ public class AddMeetingCommandParserTest {
     private static final String INVALID_INDEX_NON_NUMERIC = "a";
     private static final String INVALID_MEETING_MISSING_TIME = " m/20-10-2025";
     private static final String INVALID_MEETING_INVALID_DATE = " m/32-13-2025 14:30";
+    private static final String INVALID_MEETING_INVALID_DESCRIPTION = " m/30-10-2025 14:30 "
+            + "afkasdnfsnfnsdjfnsajfjfjsnjfnsjnfsafnjasfsfnjsnfjsanjfsanjfnjsfnjsnfjnsjanfjasnfj"
+            + "fsafadsfsdfdsafsafsdafasdfadsfasdfadsfsadfadsfadsfasdfdsafafdsfadsfsafsadfasdfasd";
     private static final String INVALID_MEETING_INVALID_FORMAT = " m/invalid";
     private static final String VALID_INDEX = "1";
     private static final String PREAMBLE_NON_EMPTY = "extra ";
@@ -93,7 +98,7 @@ public class AddMeetingCommandParserTest {
     }
 
     @Test
-    public void parse_invalidValue_failure() {
+    public void parse_invalidIndexValue_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMeetingCommand.MESSAGE_USAGE);
 
         // invalid index - zero
@@ -102,20 +107,32 @@ public class AddMeetingCommandParserTest {
         // invalid index - non-numeric
         assertParseFailure(parser, INVALID_INDEX_NON_NUMERIC + VALID_MEETING_WITH_DESC, expectedMessage);
 
-        // invalid meeting - missing time part
-        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_MISSING_TIME, expectedMessage);
-
-        // invalid meeting - invalid date
-        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_INVALID_DATE, expectedMessage);
-
-        // invalid meeting - invalid format
-        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_INVALID_FORMAT, expectedMessage);
-
         // two invalid values, only first reported (but since wrapped, expects format message)
         assertParseFailure(parser, INVALID_INDEX_ZERO + INVALID_MEETING_INVALID_FORMAT, expectedMessage);
 
         // non-empty preamble with extra
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + VALID_INDEX + VALID_MEETING_WITH_DESC, expectedMessage);
+
+
+    }
+
+    @Test
+    public void parse_invalidMeetingValue_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_MEETING_FORMAT);
+        // invalid meeting - invalid date
+        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_INVALID_DATE, expectedMessage);
+        // invalid meeting - missing time part
+        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_MISSING_TIME, expectedMessage);
+        // invalid meeting - invalid format
+        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_INVALID_FORMAT, expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidDescriptionLength_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_DESCRIPTION_LENGTH);
+        // invalid meeting - invalid description
+        assertParseFailure(parser, VALID_INDEX + INVALID_MEETING_INVALID_DESCRIPTION, expectedMessage);
+
     }
 
     @Test


### PR DESCRIPTION
Summary:

1. Added validation for meeting description to be less than or equal to 50 characters. Description is still an optional field.
2. Added error message for description length more than 50 characters.
3. Added error message for incorrect meeting format.

This pr includes functional code changes only, documentation and javadocs will be in a seperate pr

Fix: #249 , Fix #176, and by extension Fix #253