### PR TITLE
Add guide for linux java installation

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -521,7 +521,7 @@ Affected platforms:
 - Wi-Find versions ≤ 1.6
 
 
-Workaround: Install full Unicode-compatible fonts on your Linux system, then restart Wi-Find
+Temporary workaround: Install full Unicode-compatible fonts on your Linux system, then restart Wi-Find
 ```bash
 sudo apt install fonts-noto fonts-noto-cjk fonts-noto-color-emoji fonts-noto-arabic
 ```


### PR DESCRIPTION
fix #240 
fix #242 
Unable to test and fix bug on Linux within the short timeframe for v1.6, this will be addressed in a later version. For now, added to known issues with a temporary workaround.